### PR TITLE
[todo-mvp-rxjava] Remove the presenter initialization from AddEditTaskActivity - Fix #320

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
@@ -84,8 +84,6 @@ public class AddEditTaskActivity extends AppCompatActivity {
                 addEditTaskFragment,
                 shouldLoadDataFromRepo,
                 Injection.provideSchedulerProvider());
-
-        addEditTaskFragment.setPresenter(mAddEditTaskPresenter);
     }
 
     @Override


### PR DESCRIPTION
Settings presenter from activity is not needed as it was set from
presenter constructor itself. It looks like this line of code is
redundant.